### PR TITLE
Implement Autovectorization as second parallel method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 test/
 main
 *.o
+
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ DEBUG_FLAGS=-g -Wall
 main: main.c
 	gcc $(DEBUG_FLAGS) $(VECT_FLAGS) main.c -o main
 
+# Runs the program to multiply 3x2 matrices
+# 1) Sets the test/ directory
+# 2) Creates the files with the appropriate number of items
+# 3) Runs the executable (you must pass user input manually)
 test3x2: main
 	rm -rf ./test/
 	mkdir ./test/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+VECT_FLAGS=-O -ftree-vectorize -mavx2 -march=native -fopt-info-vec
+DEBUG_FLAGS=-g -Wall
+
+main: main.c
+	gcc $(DEBUG_FLAGS) $(VECT_FLAGS) main.c -o main
+
+test3x2: main
+	rm -rf ./test/
+	mkdir ./test/
+	head -n 6 sample_data/matrixA2500.txt > ./test/matrixA.txt
+	head -n 6 sample_data/matrixB2500.txt > ./test/matrixB.txt
+	./main
+
+clean:
+	rm -f ./main
+	rm -rf ./test/

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ test1024x1024: main
 	head -n 1048576 sample_data/matrixB1048576.txt > ./test/matrixB.txt
 	./main
 
+# The file will have less items than the expected given the matrix dimensions
+# When run, input 50 as the matrix size for both matrix A and B
 test-smaller-than-expected: main
 	rm -rf ./test/
 	mkdir ./test/
@@ -37,11 +39,22 @@ test-smaller-than-expected: main
 	head -n 2000 sample_data/matrixB2500.txt > ./test/matrixB.txt
 	./main
 
+# The file will have more items than the expected given the matrix dimensions
+# When run, input any number less than 50 as the matrix size for both matrix A and B
 test-larger-than-expected: main
 	rm -rf ./test/
 	mkdir ./test/
-	head -n 2000 sample_data/matrixA2500.txt > ./test/matrixA.txt
-	head -n 2000 sample_data/matrixB2500.txt > ./test/matrixB.txt
+	head -n 2500 sample_data/matrixA2500.txt > ./test/matrixA.txt
+	head -n 2500 sample_data/matrixB2500.txt > ./test/matrixB.txt
+	./main
+
+# Input a number larger than what malloc can return to you
+# Tested value for the dims was 1000000000
+test-too-large-for-malloc:
+	rm -rf ./test/
+	mkdir ./test/
+	head -n 2500 sample_data/matrixA2500.txt > ./test/matrixA.txt
+	head -n 2500 sample_data/matrixB2500.txt > ./test/matrixB.txt
 	./main
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 VECT_FLAGS=-O -ftree-vectorize -mavx2 -march=native -fopt-info-vec
+OMP_FLAGS=-fopenmp
 DEBUG_FLAGS=-g -Wall
 
 main: main.c
-	gcc $(DEBUG_FLAGS) $(VECT_FLAGS) main.c -o main
+	gcc $(DEBUG_FLAGS) $(VECT_FLAGS) $(OMP_FLAGS) main.c -o main
 
 # Runs the program to multiply 3x2 matrices
 # 1) Sets the test/ directory
@@ -13,6 +14,34 @@ test3x2: main
 	mkdir ./test/
 	head -n 6 sample_data/matrixA2500.txt > ./test/matrixA.txt
 	head -n 6 sample_data/matrixB2500.txt > ./test/matrixB.txt
+	./main
+
+test50x50: main
+	rm -rf ./test/
+	mkdir ./test/
+	head -n 2500 sample_data/matrixA2500.txt > ./test/matrixA.txt
+	head -n 2500 sample_data/matrixB2500.txt > ./test/matrixB.txt
+	./main
+
+test1024x1024: main
+	rm -rf ./test/
+	mkdir ./test/
+	head -n 1048576 sample_data/matrixA1048576.txt > ./test/matrixA.txt
+	head -n 1048576 sample_data/matrixB1048576.txt > ./test/matrixB.txt
+	./main
+
+test-smaller-than-expected: main
+	rm -rf ./test/
+	mkdir ./test/
+	head -n 2000 sample_data/matrixA2500.txt > ./test/matrixA.txt
+	head -n 2000 sample_data/matrixB2500.txt > ./test/matrixB.txt
+	./main
+
+test-larger-than-expected: main
+	rm -rf ./test/
+	mkdir ./test/
+	head -n 2000 sample_data/matrixA2500.txt > ./test/matrixA.txt
+	head -n 2000 sample_data/matrixB2500.txt > ./test/matrixB.txt
 	./main
 
 clean:

--- a/main.c
+++ b/main.c
@@ -80,8 +80,8 @@ int load_matrix(char* file_name, struct matrix* mtx_p) {
     
     // https://stackoverflow.com/questions/3501338/c-read-file-line-by-line
     int EOF_found = 0;
-    for (int i = 0; i < mtx_p->N && !EOF_found; i++) {
-        for (int j = 0; j < mtx_p->M && !EOF_found; j++) {
+    for (int i = 0; (i < mtx_p->N + 1) && !EOF_found; i++) {
+        for (int j = 0; (j < mtx_p->M + 1) && !EOF_found; j++) {
             read = getline(&line, &len, fp);
             if (read == EOF) {
                 EOF_found = 1;
@@ -89,7 +89,7 @@ int load_matrix(char* file_name, struct matrix* mtx_p) {
 
             // Check if file has more numbers than expected
             if (rows_counter > mtx_p->size) {
-                printf("Error: Matrix is larger than specified\n");
+                printf("Error: File has more items than expected\n");
                 free_matrix(mtx_p);
                 fclose(fp);
                 if (line) {
@@ -105,7 +105,7 @@ int load_matrix(char* file_name, struct matrix* mtx_p) {
     
     // Check if file has less numbers than expected
     if (rows_counter < mtx_p->size) {
-        printf("Error: Matrix is smaller than specified\n");
+        printf("Error: File has less items than expected\n");
         free_matrix(mtx_p);
         fclose(fp);
         if (line) {
@@ -147,11 +147,12 @@ int read_matrix_size(struct matrix* mtx_p) {
     return 0;
 }
 
-void transpose_matrix(struct matrix* mtx){
+void transpose_matrix(struct matrix* mtx_p){
     struct matrix m_aux;
-    m_aux.rows = mtx ->columns;
-    m_aux.columns = mtx ->rows;
-    m_aux.size = mtx->columns * mtx->rows;
+    // Aux matrix will have the transposed dimensions of mtx_p
+    m_aux.rows = mtx_p->columns;
+    m_aux.columns = mtx_p->rows;
+    m_aux.size = mtx_p->columns * mtx_p->rows;
 
     // Allocate space for the auxiliar matrix
     allocate_matrix(&m_aux);
@@ -159,24 +160,24 @@ void transpose_matrix(struct matrix* mtx){
     //Transpose
     for (int i = 0; i < m_aux.columns; ++i){
         for (int j = 0; j < m_aux.rows; ++j) {
-            m_aux.start[j][i] = mtx->start[i][j];
+            m_aux.start[j][i] = mtx_p->start[i][j];
         }
     }
 
-    int tempC = mtx->columns;
-    mtx->columns = m_aux.columns;
+    int tempC = mtx_p->columns;
+    mtx_p->columns = m_aux.columns;
     m_aux.columns = tempC;
 
-    int tempR = mtx->rows;
-    mtx->rows = m_aux.rows;
+    int tempR = mtx_p->rows;
+    mtx_p->rows = m_aux.rows;
     m_aux.rows = tempR;
 
-    double** temp = mtx->start;
-    mtx->start = m_aux.start;
-    m_aux.start = temp;
+    double* temp = *(mtx_p->start);
+    *(mtx_p->start) = *(m_aux.start);
+    *(m_aux.start) = temp;
 
     // Free the space of the auxiliar matrix 
-    free_matrix(&m_aux);
+    free_matrix(&m_aux);    
 }
 
 int save_matrix(struct matrix* mtx_p) {
@@ -262,14 +263,14 @@ int main(int argc, char const *argv[])
     int ret = 0;
 
     // Ask for matrix A size
-    printf("Matrix A\n");
+    printf("\nMatrix A\n");
     ret = read_matrix_size(&matrix_A);
     if (ret) {
         return 1;
     }
 
     // Ask for matrix B size
-    printf("Matrix B\n");
+    printf("\nMatrix B\n");
     ret = read_matrix_size(&matrix_B);
     if (ret) {
         return 1;

--- a/main.c
+++ b/main.c
@@ -89,6 +89,10 @@ int load_matrix(char* file_name, struct matrix* mtx_p) {
             if (rows_counter > mtx_p->size) {
                 printf("Error: Matrix is larger than specified\n");
                 free_matrix(mtx_p);
+                fclose(fp);
+                if (line) {
+                    free(line);
+                }
                 return 1;
             }
 
@@ -101,6 +105,10 @@ int load_matrix(char* file_name, struct matrix* mtx_p) {
     if (rows_counter < mtx_p->size) {
         printf("Error: Matrix is smaller than specified\n");
         free_matrix(mtx_p);
+        fclose(fp);
+        if (line) {
+            free(line);
+        }
         return 1;
     }
 


### PR DESCRIPTION
The Autovectorization method was selected to be the second optimization to use as part of the matrix multiplication program. It was implemented by setting the appropriate GCC compiler flags (`-O -ftree-vectorize -mavx2 -march=native -fopt-info-vec`).

## Changes introduced

- [x] Matrix multiplication methods were encapsulated into their own function
- [x] Makefile included to aid in testing and building the project
- [x] Additional checks when reading matrix size 

**UPDATE**:
- [x] OpenMP parallellization method was added as part of the PR
- [x] More test cases were added to the Makefile
- [x] Time metrics taken for each method